### PR TITLE
Correct non-ASCII character width in themes

### DIFF
--- a/bira.zsh-theme
+++ b/bira.zsh-theme
@@ -15,6 +15,6 @@ if (( ${+functions[git-info]} )); then
   add-zsh-hook precmd git-info
 fi
 
-PS1='╭─%B%(!.%F{red]}.%F{green})%n@%m %F{blue}%~${(e)git_info[prompt]}${VIRTUAL_ENV:+" %F{green}‹${VIRTUAL_ENV:t}›"}%f%b
-╰─%B%(!.#.$)%b '
-RPS1='%B%(?..%F{red}%? ↵%f)%b'
+PS1='%{%G╭%}%{%G─%}%B%(!.%F{red]}.%F{green})%n@%m %F{blue}%~${(e)git_info[prompt]}${VIRTUAL_ENV:+" %F{green}‹${VIRTUAL_ENV:t}›"}%f%b
+%{%G╰%}%{%G─%}%B%(!.#.$)%b '
+RPS1='%B%(?..%F{red}%? %{%G↵%}%f)%b'


### PR DESCRIPTION
Shell: zsh 5.9
---
Addresses an issue where non-ASCII characters (e.g., '╭─', '╰─', '↵') in the Zsh prompt caused cursor misalignment and autocomplete duplication.

The problem occurred because Zsh sometimes incorrectly assumed these "fancy" UTF-8 characters. This led to inaccurate prompt width calculations, especially after command execution (like a failed command) or when autocomplete suggestions appeared.

This fix explicitly tells Zsh to treat these characters as single-width by wrapping them with the `%{%G<character>%}` escape sequence within the theme's prompt definitions. For example, `➜` becomes `%{%G➜%}`. This ensures accurate cursor positioning and resolves display issues.
